### PR TITLE
Fix wrong module names

### DIFF
--- a/common/mx_common_tools.py
+++ b/common/mx_common_tools.py
@@ -174,6 +174,6 @@ class MX_CommonTools(QWidget):
 
     @Slot()
     def clear_display_layers(self):
-        unload_pkgs.unload_packages(True, ['common.scripts.mx_remove_unload_ref'])
+        unload_pkgs.unload_packages(True, ['common.scripts.mx_clear_display_layers'])
         from common.scripts import mx_clear_display_layers
         mx_clear_display_layers.clear_display_layers()

--- a/rig/mx_rig_tools.py
+++ b/rig/mx_rig_tools.py
@@ -126,8 +126,8 @@ class MX_RigTools(QWidget):
 
     @Slot()
     def fit_ground(self):
-        
-        unload_pkgs.unload_packages(True, ['rig.scripts.mx_auto_fit_fit_ground'])
+
+        unload_pkgs.unload_packages(True, ['rig.scripts.mx_auto_fit_ground'])
         from rig.scripts import mx_auto_fit_ground
         mx_auto_fit_ground.auto_fit_ground()
 
@@ -135,7 +135,7 @@ class MX_RigTools(QWidget):
     @Slot()
     def create_ctrl(self):
 
-        unload_pkgs.unload_packages(True, ['rig.scripts.mx_auto_fit_fit_ground'])
+        unload_pkgs.unload_packages(True, ['rig.scripts.mx_auto_fit_ground'])
         from rig.scripts import mx_create_ctrl
         mcc = mx_create_ctrl.MX_CreateCtrl()
 


### PR DESCRIPTION
## Summary
- correct module unload names for clear display layers
- fix typo in rig tools for fit ground and create ctrl

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fed118820832b9eb19306ecb093f0